### PR TITLE
Giveaway System - Fixed? the function that stops the giveaway after a bot restart.

### DIFF
--- a/Giveaway System/Functions/GiveawaySys.js
+++ b/Giveaway System/Functions/GiveawaySys.js
@@ -14,7 +14,7 @@ module.exports = (client) => {
             const guild = client.guilds.cache.get(data.GuildID);
             if (!guild) return;
 
-            const message = guild.channels.cache.get(data.ChannelID)?.messages.fetch(data.MessageID);
+            const message = await guild.channels.cache.get(data.ChannelID)?.messages.fetch(data.MessageID);
             if (!message) return;
 
             if ((data.EndTime * 1000) < Date.now()) endGiveaway(message);


### PR DESCRIPTION
In my case for some reason by default how you did it, after a bot restart, the giveaway just wouldn't finish, and I added an await at the time of fetching the message and now it did stop the giveaway after a bot restart, it seems simple, but it caused me a few problems. 😔